### PR TITLE
Small change to the RE search button

### DIFF
--- a/Auctionator/Auctionator.lua
+++ b/Auctionator/Auctionator.lua
@@ -728,7 +728,7 @@ end
 
 -----------------------------------------
 function Atr_REsearch_Toggle()
-	if (Atr_RESearch or Atr_RESearch == nil) then
+	if (Atr_RESearch) then
 			 Atr_RESearch = false;
 	 else
 			 Atr_RESearch = true;

--- a/Auctionator/Auctionator.lua
+++ b/Auctionator/Auctionator.lua
@@ -728,7 +728,7 @@ end
 
 -----------------------------------------
 function Atr_REsearch_Toggle()
-	if (Atr_RESearch) then
+	if (Atr_RESearch or Atr_RESearch == nil) then
 			 Atr_RESearch = false;
 	 else
 			 Atr_RESearch = true;

--- a/Auctionator/Auctionator.xml
+++ b/Auctionator/Auctionator.xml
@@ -549,7 +549,7 @@
 						<Size><AbsDimension x="30" y="30"/>	</Size>
 						<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="185" y="30"/></Offset></Anchor></Anchors>
 						<Scripts>
-						<OnLoad>Atr_REsearch_Toggle()</OnLoad>
+						<OnLoad>Atr_RESearch=false</OnLoad>
 						<OnClick>Atr_REsearch_Toggle()</OnClick>
 						</Scripts>
 					</CheckButton>

--- a/Auctionator/Auctionator.xml
+++ b/Auctionator/Auctionator.xml
@@ -545,7 +545,7 @@
 				</Layers>
 				
 				<Frames>
-					<CheckButton name="Atr_RESearch" inherits="UICheckButtonTemplate" enableMouse="true">
+					<CheckButton name="Atr_RE_Search" inherits="UICheckButtonTemplate" enableMouse="true">
 						<Size><AbsDimension x="30" y="30"/>	</Size>
 						<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="185" y="30"/></Offset></Anchor></Anchors>
 						<Scripts>


### PR DESCRIPTION
Instead of using the same name for both the button and the value its toggling, we separate them so that the button is interactable by its name with other scripts.